### PR TITLE
metabench_add_benchmark should use current CMAKE_CXX_COMPILER and CMAKE_CXX_FLAGS

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,4 +7,5 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 include(metabench)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 metabench_add_benchmark(path.to.benchmark "path/to/benchmark")

--- a/example/path/to/benchmark/chart.json
+++ b/example/path/to/benchmark/chart.json
@@ -32,8 +32,7 @@
             # This file is also passed through CMake `configure_file`, so
             # variables defined in the CMake file that calls `add_benchmark`
             # can also be used here.
-            cxx: '@CMAKE_CXX_COMPILER@',
-            cxxflags: '-std=c++11 -I @CMAKE_SOURCE_DIR@/include',
+            cxxflags: '-I @CMAKE_SOURCE_DIR@/include',
             env: {variable: "foo"}
         )
       %>
@@ -42,10 +41,7 @@
     , {
       "name": "recursive tuple",
       "data": <%=
-        Metabench.compile_time("recursive_tuple.cpp", (0...50).step(5),
-            cxx: '@CMAKE_CXX_COMPILER@',
-            cxxflags: '-std=c++11'
-        )
+        Metabench.compile_time("recursive_tuple.cpp", (0...50).step(5))
       %>
     }
   ]

--- a/metabench.cmake
+++ b/metabench.cmake
@@ -128,7 +128,7 @@ endfunction()
 # copy the `metabench.cmake` module to their project, without worrying
 # about implementation details.
 ##############################################################################
-set(METABENCH_RB_PATH ${CMAKE_CURRENT_BINARY_DIR}/_metabench/metabench.rb)
+set(METABENCH_RB_PATH ${CMAKE_CURRENT_BINARY_DIR}/_metabench/metabench.rb.in)
 file(WRITE ${METABENCH_RB_PATH}
 "require 'benchmark'                                                                               \n"
 "require 'open3'                                                                                   \n"

--- a/test/ctest_target/benchmark/chart.json
+++ b/test/ctest_target/benchmark/chart.json
@@ -1,2 +1,1 @@
-<%= Metabench.compile_time("dummy.cpp", (0..50).step(5),
-                           cxx: '@CMAKE_CXX_COMPILER@') %>
+<%= Metabench.compile_time("dummy.cpp", (0..50).step(5)) %>


### PR DESCRIPTION
This avoids the redundant cxx parameter in the chart.json and also allows common compile flags to be passed onto various benchmarks instead of specifying them per benchmark via chart.json