### PR TITLE
target dependencies shouldn't be filtered by extensions

### DIFF
--- a/metabench.cmake
+++ b/metabench.cmake
@@ -72,9 +72,7 @@ function(metabench_add_benchmark target path_to_dir)
 
     # Dependencies of the benchmark; the benchmark will be considered
     # outdated when any of these is changed.
-    file(GLOB dependencies "${CMAKE_CURRENT_SOURCE_DIR}/${path_to_dir}/chart.json"
-                           "${CMAKE_CURRENT_SOURCE_DIR}/${path_to_dir}/*.cpp"
-                           "${CMAKE_CURRENT_SOURCE_DIR}/${path_to_dir}/*.hpp")
+    file(GLOB dependencies "${CMAKE_CURRENT_SOURCE_DIR}/${path_to_dir}/*")
 
     # We pass the chart.json file through CMake's `configure_file`.
     set(configured_chart_json "${CMAKE_CURRENT_BINARY_DIR}/_metabench/${path_to_dir}/chart.json")


### PR DESCRIPTION
rationale: a benchmark is a directory and should depend on anything within