### PR TITLE
Remove all external Ruby dependencies

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,16 +24,10 @@ install:
   - if "%CMAKE_GENERATOR%" equ "Unix Makefiles" (set "PATH=C:\cygwin\bin;%PATH%")
   - if "%CMAKE_GENERATOR%" equ "MSYS Makefiles" (set "PATH=C:\MinGW\bin;C:\MinGW\msys\1.0\bin;%PATH%")
 
-  ############################################################################
-  # Use a more recent Ruby by default, and install required gems
-  #
-  # Note that we set the RUBY_LIBRARY variable explicitly because CMake fails
-  # to find it otherwise.
-  ############################################################################
+  # Use a more recent Ruby by default. We need to set the RUBY_LIBRARY variable
+  # explicitly because CMake fails to find it otherwise.
   - set PATH=C:\Ruby21-x64;C:\Ruby21-x64\bin;%PATH%
   - ruby --version
-  - gem --version
-  - gem install ruby-progressbar
   - set RUBY_LIBRARY="C:\Ruby21-x64\lib\libx64-msvcrt-ruby210-static.a"
 
 before_build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
   - set PATH=C:\Ruby21-x64;C:\Ruby21-x64\bin;%PATH%
   - ruby --version
   - gem --version
-  - gem install ruby-progressbar tilt
+  - gem install ruby-progressbar
   - set RUBY_LIBRARY="C:\Ruby21-x64\lib\libx64-msvcrt-ruby210-static.a"
 
 before_build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
   # Install and use a more recent Ruby and install the gems for the benchmarks
   - rvm use 2.1 --install --binary --fuzzy
-  - gem install ruby-progressbar tilt
+  - gem install ruby-progressbar
 
 script:
   - cd ${TRAVIS_BUILD_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,8 @@ install:
   - mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
   - export PATH=${DEPS_DIR}/cmake/bin:${PATH}
 
-  # Install and use a more recent Ruby and install the gems for the benchmarks
+  # Install and use a more recent Ruby
   - rvm use 2.1 --install --binary --fuzzy
-  - gem install ruby-progressbar
 
 script:
   - cd ${TRAVIS_BUILD_DIR}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ still allowing fairly complex benchmarks to be written.
 
 ### Dependencies
 Metabench requires [CMake][] 3.1 or higher. It also requires [Ruby][] 2.1 or
-higher along with the [Progressbar][] and [Tilt][] gems.
+higher along with the [Progressbar][] gem. To install the Progressbar gem,
+you can issue
+
+```sh
+gem install ruby-progressbar
+```
 
 ### Usage
 To use Metabench, make sure you have the dependencies listed above and simply
@@ -124,5 +129,4 @@ it into its own project.
 [ERB]: http://en.wikipedia.org/wiki/ERuby
 [Progressbar]: https://rubygems.org/gems/ruby-progressbar
 [Ruby]: https://www.ruby-lang.org/en/
-[Tilt]: https://rubygems.org/gems/tilt
 [NVD3]: http://nvd3.org/

--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@ long compilation times. Metabench was designed to be very simple to use, while
 still allowing fairly complex benchmarks to be written.
 
 ### Dependencies
-Metabench requires [CMake][] 3.1 or higher. It also requires [Ruby][] 2.1 or
-higher along with the [Progressbar][] gem. To install the Progressbar gem,
-you can issue
-
-```sh
-gem install ruby-progressbar
-```
+Metabench requires [CMake][] 3.1 or higher and [Ruby][] 2.1 or higher.
 
 ### Usage
 To use Metabench, make sure you have the dependencies listed above and simply
@@ -127,6 +121,5 @@ it into its own project.
 [Boost.Hana]: http://github.com/boostorg/hana
 [CMake]: http://www.cmake.org
 [ERB]: http://en.wikipedia.org/wiki/ERuby
-[Progressbar]: https://rubygems.org/gems/ruby-progressbar
 [Ruby]: https://www.ruby-lang.org/en/
 [NVD3]: http://nvd3.org/

--- a/metabench.cmake
+++ b/metabench.cmake
@@ -88,9 +88,10 @@ function(metabench_add_dataset target path_to_template range)
             -e "measure_file = '${METABENCH_DIR}/${path_to}/${target}.cpp'"
             -e "exe_file = '${METABENCH_DIR}/${path_to}/${target}${CMAKE_EXECUTABLE_SUFFIX}'"
             -e "command = ['${CMAKE_COMMAND}', '--build', '${CMAKE_BINARY_DIR}', '--target', '${target}']"
-            -e "data = Metabench.compile_time('${CMAKE_CURRENT_SOURCE_DIR}/${path_to_template}', range, measure_file, exe_file, command)"
+            -e "data = Metabench.compile_time('${path_to_template}', range, measure_file, exe_file, command)"
             -e "IO.write('${json_file}', JSON.generate(data))"
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${path_to_template}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         VERBATIM USES_TERMINAL
     )
 
@@ -104,7 +105,8 @@ function(metabench_add_dataset target path_to_template range)
             -e "measure_file = '${METABENCH_DIR}/${path_to}/${target}.cpp'"
             -e "exe_file = '${METABENCH_DIR}/${path_to}/${target}${CMAKE_EXECUTABLE_SUFFIX}'"
             -e "command = ['${CMAKE_COMMAND}', '--build', '${CMAKE_BINARY_DIR}', '--target', '${target}']"
-            -e "data = Metabench.compile_time(\"${CMAKE_CURRENT_SOURCE_DIR}/${path_to_template}\", range, measure_file, exe_file, command)"
+            -e "data = Metabench.compile_time(\"${path_to_template}\", range, measure_file, exe_file, command)"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endfunction()
 

--- a/metabench.cmake
+++ b/metabench.cmake
@@ -85,8 +85,8 @@ function(metabench_add_dataset target path_to_template range)
     add_custom_command(OUTPUT ${json_file}
         COMMAND ${RUBY_EXECUTABLE} -r json -r ${METABENCH_RB_PATH}
             -e "range = (${range})"
-            -e "measure_file = Pathname.new('${METABENCH_DIR}/${path_to}/${target}.cpp')"
-            -e "exe_file = Pathname.new('${METABENCH_DIR}/${path_to}/${target}${CMAKE_EXECUTABLE_SUFFIX}')"
+            -e "measure_file = '${METABENCH_DIR}/${path_to}/${target}.cpp'"
+            -e "exe_file = '${METABENCH_DIR}/${path_to}/${target}${CMAKE_EXECUTABLE_SUFFIX}'"
             -e "command = ['${CMAKE_COMMAND}', '--build', '${CMAKE_BINARY_DIR}', '--target', '${target}']"
             -e "data = Metabench.compile_time('${CMAKE_CURRENT_SOURCE_DIR}/${path_to_template}', range, measure_file, exe_file, command)"
             -e "IO.write('${json_file}', JSON.generate(data))"
@@ -101,8 +101,8 @@ function(metabench_add_dataset target path_to_template range)
         COMMAND ${RUBY_EXECUTABLE} -r ${METABENCH_RB_PATH}
             -e "range = (${range}).to_a"
             -e "range = [range[0], range[-1]] if range.length >= 2"
-            -e "measure_file = Pathname.new('${METABENCH_DIR}/${path_to}/${target}.cpp')"
-            -e "exe_file = Pathname.new('${METABENCH_DIR}/${path_to}/${target}${CMAKE_EXECUTABLE_SUFFIX}')"
+            -e "measure_file = '${METABENCH_DIR}/${path_to}/${target}.cpp'"
+            -e "exe_file = '${METABENCH_DIR}/${path_to}/${target}${CMAKE_EXECUTABLE_SUFFIX}'"
             -e "command = ['${CMAKE_COMMAND}', '--build', '${CMAKE_BINARY_DIR}', '--target', '${target}']"
             -e "data = Metabench.compile_time(\"${CMAKE_CURRENT_SOURCE_DIR}/${path_to_template}\", range, measure_file, exe_file, command)"
     )
@@ -190,12 +190,8 @@ endfunction()
 ################################################################################
 set(METABENCH_RB_PATH ${METABENCH_DIR}/metabench.rb)
 file(WRITE ${METABENCH_RB_PATH}
-"require 'benchmark'                                                                                    \n"
 "require 'erb'                                                                                          \n"
 "require 'open3'                                                                                        \n"
-"require 'pathname'                                                                                     \n"
-"require 'tempfile'                                                                                     \n"
-"                                                                                                       \n"
 "                                                                                                       \n"
 "module Metabench                                                                                       \n"
 "  # This function is meant to be called inside a ERB-based `chart.json` file.                          \n"
@@ -210,7 +206,7 @@ file(WRITE ${METABENCH_RB_PATH}
 "      # Evaluate the ERB template with the given environment, and save the                             \n"
 "      # result in a temporary file.                                                                    \n"
 "      code = ERB.new(File.read(erb_template)).result(binding)                                          \n"
-"      measure_file.write(code)                                                                         \n"
+"      IO.write(measure_file, code)                                                                     \n"
 "      data = {n: n}                                                                                    \n"
 "                                                                                                       \n"
 "      # Compile the file and get timing statistics. The timing statistics                              \n"
@@ -247,7 +243,7 @@ file(WRITE ${METABENCH_RB_PATH}
 "    end                                                                                                \n"
 "  ensure                                                                                               \n"
 "    STDERR.write(\"\n\") # Otherwise the output of the next CMake command appears on the same line     \n"
-"    measure_file.write('')                                                                             \n"
+"    IO.write(measure_file, '')                                                                         \n"
 "  end                                                                                                  \n"
 "                                                                                                       \n"
 "  def self.compile_time(*args)                                                                         \n"


### PR DESCRIPTION
Most of the changes are trivial, but I'd like to have thoughts on the format of the progress output. Right now, it's going to output something like

```
5/5 /Users/ldionne/code/metabench/example/decay/std_decay.cpp.erb (n = 400)
```

I think that's OK, but if you have a better idea then I'm open for suggestions (as long as it's easy to implement!).
