### PR TITLE
[Appveyor] Properly find Ruby

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,11 +24,9 @@ install:
   - if "%CMAKE_GENERATOR%" equ "Unix Makefiles" (set "PATH=C:\cygwin\bin;%PATH%")
   - if "%CMAKE_GENERATOR%" equ "MSYS Makefiles" (set "PATH=C:\MinGW\bin;C:\MinGW\msys\1.0\bin;%PATH%")
 
-  # Use a more recent Ruby by default. We need to set the RUBY_LIBRARY variable
-  # explicitly because CMake fails to find it otherwise.
+  # Use a more recent Ruby by default.
   - set PATH=C:\Ruby21-x64;C:\Ruby21-x64\bin;%PATH%
   - ruby --version
-  - set RUBY_LIBRARY="C:\Ruby21-x64\lib\libx64-msvcrt-ruby210-static.a"
 
 before_build:
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
@@ -37,6 +35,6 @@ before_build:
 build_script:
   - mkdir build
   - cd build
-  - cmake .. -G%CMAKE_GENERATOR% -DRUBY_LIBRARY=%RUBY_LIBRARY% -DMETABENCH_UNIT_TEST_OPTIONS="-DRUBY_LIBRARY=%RUBY_LIBRARY%"
+  - cmake .. -G%CMAKE_GENERATOR%
   - cmake --build .
   - ctest --output-on-failure -VV

--- a/metabench.cmake
+++ b/metabench.cmake
@@ -10,8 +10,8 @@
 
 cmake_minimum_required(VERSION 3.0)
 
-find_package(Ruby 2.1)
-if(NOT ${RUBY_FOUND})
+find_package(Ruby 2.1 QUIET)
+if(NOT RUBY_EXECUTABLE)
     message(WARNING "Ruby >= 2.1 was not found; the metabench.cmake module can't be used.")
     return()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,9 +6,6 @@
 # and possibly CTest targets. This might look a bit odd, because we're using
 # CMake to run CMake, but we do this instead of using `add_subdirectory` to
 # make sure each test is run in its own "sandbox".
-#
-# The METABENCH_UNIT_TEST_OPTIONS variable can be used to pass options down to
-# the unit tests. It is used e.g. in the Appveyor build.
 
 file(GLOB test_dirs
     LIST_DIRECTORIES true
@@ -24,7 +21,7 @@ foreach(dir ${test_dirs})
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${dir}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
         COMMAND ${CMAKE_COMMAND} -E chdir ${dir}
-                ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${dir} -G${CMAKE_GENERATOR} ${METABENCH_UNIT_TEST_OPTIONS}
+                ${CMAKE_COMMAND} ${CMAKE_CURRENT_SOURCE_DIR}/${dir} -G${CMAKE_GENERATOR}
         COMMAND ${CMAKE_COMMAND} --build ${dir} --target check
         COMMAND ${CMAKE_COMMAND} -E chdir ${dir}
                 ${CMAKE_CTEST_COMMAND} --output-on-failure


### PR DESCRIPTION
Right now, the FindRuby module is unable to find the ruby library. To workaround this, we currently set the `RUBY_LIBRARY` CMake variable explicitly in `.appveyor.yml`. This PR is an attempt to fix this.