### PR TITLE
Provide greater control over the dependencies

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -35,6 +35,7 @@ if (METABENCH_BRIGAND)
             BUILD_COMMAND ""   # Disable build step
             INSTALL_COMMAND "" # Disable install step
             TEST_COMMAND ""    # Disable test step
+            UPDATE_COMMAND ""  # Disable source work-tree update
         )
         ExternalProject_Get_Property(Brigand SOURCE_DIR)
         include_directories(${SOURCE_DIR})
@@ -58,6 +59,7 @@ if (METABENCH_HANA)
             BUILD_COMMAND ""   # Disable build step
             INSTALL_COMMAND "" # Disable install step
             TEST_COMMAND ""    # Disable test step
+            UPDATE_COMMAND ""  # Disable source work-tree update
         )
         ExternalProject_Get_Property(Hana SOURCE_DIR)
         include_directories(${SOURCE_DIR}/include)
@@ -81,6 +83,7 @@ if (METABENCH_META)
             BUILD_COMMAND ""   # Disable build step
             INSTALL_COMMAND "" # Disable install step
             TEST_COMMAND ""    # Disable test step
+            UPDATE_COMMAND ""  # Disable source work-tree update
         )
         ExternalProject_Get_Property(Meta SOURCE_DIR)
         include_directories(${SOURCE_DIR}/include)
@@ -104,6 +107,7 @@ if (METABENCH_METAL)
             BUILD_COMMAND ""   # Disable build step
             INSTALL_COMMAND "" # Disable install step
             TEST_COMMAND ""    # Disable test step
+            UPDATE_COMMAND ""  # Disable source work-tree update
         )
         ExternalProject_Get_Property(Metal SOURCE_DIR)
         include_directories(${SOURCE_DIR}/include)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -12,20 +12,25 @@ option(METABENCH_MPL        "Benchmark MPL"     ON)
 include(ExternalProject)
 
 if (METABENCH_FUSION OR METABENCH_MPL)
-    find_package(Boost)
+    find_package(Boost QUIET)
     if (Boost_FOUND)
+        message(STATUS "Boost found - version ${Boost_VERSION}")
         include_directories(${Boost_INCLUDE_DIRS})
+    else()
+        message(WARNING "Boost not found - Fusion and MPL will be unavailable.")
+        set(METABENCH_FUSION OFF)
+        set(METABENCH_MPL OFF)
     endif()
 endif()
 
 if (METABENCH_BRIGAND)
     find_package(Brigand QUIET)
     if (Brigand_FOUND)
-        message(STATUS "Brigand version: ${Brigand_VERSION}")
+        message(STATUS "Brigand found - version ${Brigand_VERSION}")
         #TODO: add directories here
         add_custom_target(Brigand)
     else()
-        message(STATUS "Brigand version: branch master")
+        message(STATUS "Brigand not found - fetching branch master")
         ExternalProject_Add(Brigand
             URL https://github.com/edouarda/brigand/archive/master.zip
             TIMEOUT 10
@@ -44,11 +49,11 @@ endif()
 if (METABENCH_HANA)
     find_package(Hana QUIET)
     if (Hana_FOUND)
-        message(STATUS "Hana version: ${Hana_VERSION}")
+        message(STATUS "Hana found - version ${Hana_VERSION}")
         #TODO: add directories here
         add_custom_target(Hana)
     else()
-        message(STATUS "Hana version: branch develop")
+        message(STATUS "Hana not found - fetching branch develop")
         ExternalProject_Add(Hana
             URL https://github.com/ldionne/hana/archive/develop.zip
             TIMEOUT 10
@@ -67,11 +72,11 @@ endif()
 if (METABENCH_META)
     find_package(Meta QUIET)
     if (Meta_FOUND)
-        message(STATUS "Meta version: ${Meta_VERSION}")
+        message(STATUS "Meta found - version ${Meta_VERSION}")
         #TODO: add directories here
         add_custom_target(Meta)
     else()
-        message(STATUS "Meta version: branch master")
+        message(STATUS "Meta not found - fetching branch master")
         ExternalProject_Add(Meta
             URL https://github.com/ericniebler/meta/archive/master.zip
             TIMEOUT 10
@@ -90,11 +95,11 @@ endif()
 if (METABENCH_METAL)
     find_package(Metal QUIET)
     if (Metal_FOUND)
-        message(STATUS "Metal version: ${Metal_VERSION}")
+        message(STATUS "Metal found - version ${Metal_VERSION}")
         include_directories(${METAL_INCLUDE_DIRS})
         add_custom_target(Metal)
     else()
-        message(STATUS "Metal version: branch master")
+        message(STATUS "Metal not found - fetching branch master")
         ExternalProject_Add(Metal
             URL https://github.com/brunocodutra/metal/archive/master.zip
             TIMEOUT 10

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -50,7 +50,7 @@ if (METABENCH_HANA)
     find_package(Hana QUIET)
     if (Hana_FOUND)
         message(STATUS "Hana found - version ${Hana_VERSION}")
-        #TODO: add directories here
+        include_directories(${Hana_INCLUDE_DIRS})
         add_custom_target(Hana)
     else()
         message(STATUS "Hana not found - fetching branch develop")

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -2,111 +2,127 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+option(METABENCH_BRIGAND    "Benchmark Brigand" ON)
+option(METABENCH_FUSION     "Benchmark Fusion"  ON)
+option(METABENCH_HANA       "Benchmark Hana"    ON)
+option(METABENCH_META       "Benchmark Meta"    ON)
+option(METABENCH_METAL      "Benchmark Metal"   ON)
+option(METABENCH_MPL        "Benchmark MPL"     ON)
+
 include(ExternalProject)
 
-# Add several metaprogramming libraries that we want to benchmark
-find_package(Boost)
-if (Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
+if (METABENCH_FUSION OR METABENCH_MPL)
+    find_package(Boost)
+    if (Boost_FOUND)
+        include_directories(${Boost_INCLUDE_DIRS})
+    endif()
 endif()
 
-find_package(Brigand QUIET)
-if (Brigand_FOUND)
-    message(STATUS "Brigand version: ${Brigand_VERSION}")
-    #add directories here
-    add_custom_target(Brigand)
-else()
-    message(STATUS "Brigand version: origin/master")
-    ExternalProject_Add(Brigand
-        GIT_REPOSITORY https://github.com/edouarda/brigand
-        GIT_TAG origin/master
-        TIMEOUT 10
-        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-        BUILD_COMMAND ""   # Disable build step
-        INSTALL_COMMAND "" # Disable install step
-        TEST_COMMAND ""    # Disable test step
-    )
-    ExternalProject_Get_Property(Brigand SOURCE_DIR)
-    include_directories(${SOURCE_DIR})
+if (METABENCH_BRIGAND)
+    find_package(Brigand QUIET)
+    if (Brigand_FOUND)
+        message(STATUS "Brigand version: ${Brigand_VERSION}")
+        #TODO: add directories here
+        add_custom_target(Brigand)
+    else()
+        message(STATUS "Brigand version: origin/master")
+        ExternalProject_Add(Brigand
+            GIT_REPOSITORY https://github.com/edouarda/brigand
+            GIT_TAG origin/master
+            TIMEOUT 10
+            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+            PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+            BUILD_COMMAND ""   # Disable build step
+            INSTALL_COMMAND "" # Disable install step
+            TEST_COMMAND ""    # Disable test step
+        )
+        ExternalProject_Get_Property(Brigand SOURCE_DIR)
+        include_directories(${SOURCE_DIR})
+    endif()
 endif()
 
-find_package(Hana QUIET)
-if (Hana_FOUND)
-    message(STATUS "Hana version: ${Hana_VERSION}")
-    #add directories here
-    add_custom_target(Hana)
-else()
-    message(STATUS "Hana version: origin/develop")
-    ExternalProject_Add(Hana
-        GIT_REPOSITORY https://github.com/ldionne/hana
-        GIT_TAG origin/develop
-        TIMEOUT 10
-        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-        BUILD_COMMAND ""   # Disable build step
-        INSTALL_COMMAND "" # Disable install step
-        TEST_COMMAND ""    # Disable test step
-    )
-    ExternalProject_Get_Property(Hana SOURCE_DIR)
-    include_directories(${SOURCE_DIR}/include)
+if (METABENCH_HANA)
+    find_package(Hana QUIET)
+    if (Hana_FOUND)
+        message(STATUS "Hana version: ${Hana_VERSION}")
+        #TODO: add directories here
+        add_custom_target(Hana)
+    else()
+        message(STATUS "Hana version: origin/develop")
+        ExternalProject_Add(Hana
+            GIT_REPOSITORY https://github.com/ldionne/hana
+            GIT_TAG origin/develop
+            TIMEOUT 10
+            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+            PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+            BUILD_COMMAND ""   # Disable build step
+            INSTALL_COMMAND "" # Disable install step
+            TEST_COMMAND ""    # Disable test step
+        )
+        ExternalProject_Get_Property(Hana SOURCE_DIR)
+        include_directories(${SOURCE_DIR}/include)
+    endif()
 endif()
 
-find_package(Meta QUIET)
-if (Meta_FOUND)
-    message(STATUS "Meta version: ${Meta_VERSION}")
-    #add directories here
-    add_custom_target(Meta)
-else()
-    message(STATUS "Meta version: origin/master")
-    ExternalProject_Add(Meta
-        GIT_REPOSITORY https://github.com/ericniebler/meta
-        GIT_TAG origin/master
-        TIMEOUT 10
-        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-        BUILD_COMMAND ""   # Disable build step
-        INSTALL_COMMAND "" # Disable install step
-        TEST_COMMAND ""    # Disable test step
-    )
-    ExternalProject_Get_Property(Meta SOURCE_DIR)
-    include_directories(${SOURCE_DIR}/include)
+if (METABENCH_META)
+    find_package(Meta QUIET)
+    if (Meta_FOUND)
+        message(STATUS "Meta version: ${Meta_VERSION}")
+        #TODO: add directories here
+        add_custom_target(Meta)
+    else()
+        message(STATUS "Meta version: origin/master")
+        ExternalProject_Add(Meta
+            GIT_REPOSITORY https://github.com/ericniebler/meta
+            GIT_TAG origin/master
+            TIMEOUT 10
+            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+            PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+            BUILD_COMMAND ""   # Disable build step
+            INSTALL_COMMAND "" # Disable install step
+            TEST_COMMAND ""    # Disable test step
+        )
+        ExternalProject_Get_Property(Meta SOURCE_DIR)
+        include_directories(${SOURCE_DIR}/include)
+    endif()
 endif()
 
-find_package(Metal QUIET)
-if (Metal_FOUND)
-    message(STATUS "Metal version: ${Metal_VERSION}")
-    include_directories(${METAL_INCLUDE_DIRS})
-    add_custom_target(Metal)
-else()
-    message(STATUS "Metal version: origin/master")
-    ExternalProject_Add(Metal
-        GIT_REPOSITORY https://github.com/brunocodutra/metal
-        GIT_TAG origin/master
-        TIMEOUT 10
-        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-        BUILD_COMMAND ""   # Disable build step
-        INSTALL_COMMAND "" # Disable install step
-        TEST_COMMAND ""    # Disable test step
-    )
-    ExternalProject_Get_Property(Metal SOURCE_DIR)
-    include_directories(${SOURCE_DIR}/include)
+if (METABENCH_METAL)
+    find_package(Metal QUIET)
+    if (Metal_FOUND)
+        message(STATUS "Metal version: ${Metal_VERSION}")
+        include_directories(${METAL_INCLUDE_DIRS})
+        add_custom_target(Metal)
+    else()
+        message(STATUS "Metal version: origin/master")
+        ExternalProject_Add(Metal
+            GIT_REPOSITORY https://github.com/brunocodutra/metal
+            GIT_TAG origin/master
+            TIMEOUT 10
+            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+            PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+            BUILD_COMMAND ""   # Disable build step
+            INSTALL_COMMAND "" # Disable install step
+            TEST_COMMAND ""    # Disable test step
+        )
+        ExternalProject_Get_Property(Metal SOURCE_DIR)
+        include_directories(${SOURCE_DIR}/include)
+    endif()
 endif()
 
 function(dependencies_are_satisfied result dataset)
     if(${dataset} MATCHES "brigand\\.")
-        set(${result} ON PARENT_SCOPE)
+        set(${result} ${METABENCH_BRIGAND} PARENT_SCOPE)
     elseif(${dataset} MATCHES "fusion\\.")
-        set(${result} ${Boost_FOUND} PARENT_SCOPE)
+        set(${result} ${METABENCH_FUSION} PARENT_SCOPE)
     elseif(${dataset} MATCHES "hana\\.")
-        set(${result} ON PARENT_SCOPE)
+        set(${result} ${METABENCH_HANA} PARENT_SCOPE)
     elseif(${dataset} MATCHES "meta\\.")
-        set(${result} ON PARENT_SCOPE)
+        set(${result} ${METABENCH_META} PARENT_SCOPE)
     elseif(${dataset} MATCHES "metal\\.")
-        set(${result} ON PARENT_SCOPE)
+        set(${result} ${METABENCH_METAL} PARENT_SCOPE)
     elseif (${dataset} MATCHES "mpl\\.")
-        set(${result} ON PARENT_SCOPE)
+        set(${result} ${METABENCH_MPL} PARENT_SCOPE)
     elseif (${dataset} MATCHES "std\\.")
         set(${result} ON PARENT_SCOPE) # std:: is always available
     else()

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,10 +25,9 @@ if (METABENCH_BRIGAND)
         #TODO: add directories here
         add_custom_target(Brigand)
     else()
-        message(STATUS "Brigand version: origin/master")
+        message(STATUS "Brigand version: branch master")
         ExternalProject_Add(Brigand
-            GIT_REPOSITORY https://github.com/edouarda/brigand
-            GIT_TAG origin/master
+            URL https://github.com/edouarda/brigand/archive/master.zip
             TIMEOUT 10
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
             CONFIGURE_COMMAND "" # Disable configure step
@@ -49,10 +48,9 @@ if (METABENCH_HANA)
         #TODO: add directories here
         add_custom_target(Hana)
     else()
-        message(STATUS "Hana version: origin/develop")
+        message(STATUS "Hana version: branch develop")
         ExternalProject_Add(Hana
-            GIT_REPOSITORY https://github.com/ldionne/hana
-            GIT_TAG origin/develop
+            URL https://github.com/ldionne/hana/archive/develop.zip
             TIMEOUT 10
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
             CONFIGURE_COMMAND "" # Disable configure step
@@ -73,10 +71,9 @@ if (METABENCH_META)
         #TODO: add directories here
         add_custom_target(Meta)
     else()
-        message(STATUS "Meta version: origin/master")
+        message(STATUS "Meta version: branch master")
         ExternalProject_Add(Meta
-            GIT_REPOSITORY https://github.com/ericniebler/meta
-            GIT_TAG origin/master
+            URL https://github.com/ericniebler/meta/archive/master.zip
             TIMEOUT 10
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
             CONFIGURE_COMMAND "" # Disable configure step
@@ -97,10 +94,9 @@ if (METABENCH_METAL)
         include_directories(${METAL_INCLUDE_DIRS})
         add_custom_target(Metal)
     else()
-        message(STATUS "Metal version: origin/master")
+        message(STATUS "Metal version: branch master")
         ExternalProject_Add(Metal
-            GIT_REPOSITORY https://github.com/brunocodutra/metal
-            GIT_TAG origin/master
+            URL https://github.com/brunocodutra/metal/archive/master.zip
             TIMEOUT 10
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
             CONFIGURE_COMMAND "" # Disable configure step

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -30,12 +30,12 @@ if (METABENCH_BRIGAND)
             GIT_REPOSITORY https://github.com/edouarda/brigand
             GIT_TAG origin/master
             TIMEOUT 10
-            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-            BUILD_COMMAND ""   # Disable build step
-            INSTALL_COMMAND "" # Disable install step
-            TEST_COMMAND ""    # Disable test step
-            UPDATE_COMMAND ""  # Disable source work-tree update
+            CONFIGURE_COMMAND "" # Disable configure step
+            BUILD_COMMAND ""     # Disable build step
+            INSTALL_COMMAND ""   # Disable install step
+            TEST_COMMAND ""      # Disable test step
+            UPDATE_COMMAND ""    # Disable source work-tree update
         )
         ExternalProject_Get_Property(Brigand SOURCE_DIR)
         include_directories(${SOURCE_DIR})
@@ -54,12 +54,12 @@ if (METABENCH_HANA)
             GIT_REPOSITORY https://github.com/ldionne/hana
             GIT_TAG origin/develop
             TIMEOUT 10
-            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-            BUILD_COMMAND ""   # Disable build step
-            INSTALL_COMMAND "" # Disable install step
-            TEST_COMMAND ""    # Disable test step
-            UPDATE_COMMAND ""  # Disable source work-tree update
+            CONFIGURE_COMMAND "" # Disable configure step
+            BUILD_COMMAND ""     # Disable build step
+            INSTALL_COMMAND ""   # Disable install step
+            TEST_COMMAND ""      # Disable test step
+            UPDATE_COMMAND ""    # Disable source work-tree update
         )
         ExternalProject_Get_Property(Hana SOURCE_DIR)
         include_directories(${SOURCE_DIR}/include)
@@ -78,12 +78,12 @@ if (METABENCH_META)
             GIT_REPOSITORY https://github.com/ericniebler/meta
             GIT_TAG origin/master
             TIMEOUT 10
-            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-            BUILD_COMMAND ""   # Disable build step
-            INSTALL_COMMAND "" # Disable install step
-            TEST_COMMAND ""    # Disable test step
-            UPDATE_COMMAND ""  # Disable source work-tree update
+            CONFIGURE_COMMAND "" # Disable configure step
+            BUILD_COMMAND ""     # Disable build step
+            INSTALL_COMMAND ""   # Disable install step
+            TEST_COMMAND ""      # Disable test step
+            UPDATE_COMMAND ""    # Disable source work-tree update
         )
         ExternalProject_Get_Property(Meta SOURCE_DIR)
         include_directories(${SOURCE_DIR}/include)
@@ -102,12 +102,12 @@ if (METABENCH_METAL)
             GIT_REPOSITORY https://github.com/brunocodutra/metal
             GIT_TAG origin/master
             TIMEOUT 10
-            CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
             PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-            BUILD_COMMAND ""   # Disable build step
-            INSTALL_COMMAND "" # Disable install step
-            TEST_COMMAND ""    # Disable test step
-            UPDATE_COMMAND ""  # Disable source work-tree update
+            CONFIGURE_COMMAND "" # Disable configure step
+            BUILD_COMMAND ""     # Disable build step
+            INSTALL_COMMAND ""   # Disable install step
+            TEST_COMMAND ""      # Disable test step
+            UPDATE_COMMAND ""    # Disable source work-tree update
         )
         ExternalProject_Get_Property(Metal SOURCE_DIR)
         include_directories(${SOURCE_DIR}/include)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -10,58 +10,89 @@ if (Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
 endif()
 
-ExternalProject_Add(Brigand
-    GIT_REPOSITORY https://github.com/edouarda/brigand
-    GIT_TAG origin/master
-    TIMEOUT 10
-    CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-    PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-    BUILD_COMMAND ""   # Disable build step
-    INSTALL_COMMAND "" # Disable install step
-    TEST_COMMAND ""    # Disable test step
-)
-ExternalProject_Get_Property(Brigand SOURCE_DIR)
-include_directories(${SOURCE_DIR})
+find_package(Brigand QUIET)
+if (Brigand_FOUND)
+    message(STATUS "Brigand version: ${Brigand_VERSION}")
+    #add directories here
+    add_custom_target(Brigand)
+else()
+    message(STATUS "Brigand version: origin/master")
+    ExternalProject_Add(Brigand
+        GIT_REPOSITORY https://github.com/edouarda/brigand
+        GIT_TAG origin/master
+        TIMEOUT 10
+        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+        BUILD_COMMAND ""   # Disable build step
+        INSTALL_COMMAND "" # Disable install step
+        TEST_COMMAND ""    # Disable test step
+    )
+    ExternalProject_Get_Property(Brigand SOURCE_DIR)
+    include_directories(${SOURCE_DIR})
+endif()
 
-ExternalProject_Add(Hana
-    GIT_REPOSITORY https://github.com/ldionne/hana
-    GIT_TAG origin/develop
-    TIMEOUT 10
-    CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-    PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-    BUILD_COMMAND ""   # Disable build step
-    INSTALL_COMMAND "" # Disable install step
-    TEST_COMMAND ""    # Disable test step
-)
-ExternalProject_Get_Property(Hana SOURCE_DIR)
-include_directories(${SOURCE_DIR}/include)
+find_package(Hana QUIET)
+if (Hana_FOUND)
+    message(STATUS "Hana version: ${Hana_VERSION}")
+    #add directories here
+    add_custom_target(Hana)
+else()
+    message(STATUS "Hana version: origin/develop")
+    ExternalProject_Add(Hana
+        GIT_REPOSITORY https://github.com/ldionne/hana
+        GIT_TAG origin/develop
+        TIMEOUT 10
+        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+        BUILD_COMMAND ""   # Disable build step
+        INSTALL_COMMAND "" # Disable install step
+        TEST_COMMAND ""    # Disable test step
+    )
+    ExternalProject_Get_Property(Hana SOURCE_DIR)
+    include_directories(${SOURCE_DIR}/include)
+endif()
 
-ExternalProject_Add(Meta
-    GIT_REPOSITORY https://github.com/ericniebler/meta
-    GIT_TAG origin/master
-    TIMEOUT 10
-    CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-    PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-    BUILD_COMMAND ""   # Disable build step
-    INSTALL_COMMAND "" # Disable install step
-    TEST_COMMAND ""    # Disable test step
-)
-ExternalProject_Get_Property(Meta SOURCE_DIR)
-include_directories(${SOURCE_DIR}/include)
+find_package(Meta QUIET)
+if (Meta_FOUND)
+    message(STATUS "Meta version: ${Meta_VERSION}")
+    #add directories here
+    add_custom_target(Meta)
+else()
+    message(STATUS "Meta version: origin/master")
+    ExternalProject_Add(Meta
+        GIT_REPOSITORY https://github.com/ericniebler/meta
+        GIT_TAG origin/master
+        TIMEOUT 10
+        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+        BUILD_COMMAND ""   # Disable build step
+        INSTALL_COMMAND "" # Disable install step
+        TEST_COMMAND ""    # Disable test step
+    )
+    ExternalProject_Get_Property(Meta SOURCE_DIR)
+    include_directories(${SOURCE_DIR}/include)
+endif()
 
-ExternalProject_Add(Metal
-    GIT_REPOSITORY https://github.com/brunocodutra/metal
-    GIT_TAG origin/master
-    TIMEOUT 10
-    CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-    PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
-    BUILD_COMMAND ""   # Disable build step
-    INSTALL_COMMAND "" # Disable install step
-    TEST_COMMAND ""    # Disable test step
-)
-ExternalProject_Get_Property(Metal SOURCE_DIR)
-include_directories(${SOURCE_DIR}/include)
-
+find_package(Metal QUIET)
+if (Metal_FOUND)
+    message(STATUS "Metal version: ${Metal_VERSION}")
+    include_directories(${METAL_INCLUDE_DIRS})
+    add_custom_target(Metal)
+else()
+    message(STATUS "Metal version: origin/master")
+    ExternalProject_Add(Metal
+        GIT_REPOSITORY https://github.com/brunocodutra/metal
+        GIT_TAG origin/master
+        TIMEOUT 10
+        CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+        BUILD_COMMAND ""   # Disable build step
+        INSTALL_COMMAND "" # Disable install step
+        TEST_COMMAND ""    # Disable test step
+    )
+    ExternalProject_Get_Property(Metal SOURCE_DIR)
+    include_directories(${SOURCE_DIR}/include)
+endif()
 
 function(dependencies_are_satisfied result dataset)
     if(${dataset} MATCHES "brigand\\.")


### PR DESCRIPTION
The user may now:

- use locally installed versions
- disable specific libraries
- clone boost

Also, fetching libraries got much faster by downloading a zip archive instead of cloning the whole source tree (CMake does not add --depth=1)