### PR TITLE
Load iframes individually instead of batching them

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@ compilers:
             <div class="panel-group">
               {% for benchmark in site.documents %}
               <div class="chart panel panel-default" data-collection="{{ benchmark.collection }}" data-compiler="{{ benchmark.compiler }}" style="display: none">
-                <div class="panel-heading" data-toggle="collapse" data-target="#chart{{ forloop.index }}" role="button">
+                <div class="panel-heading" data-toggle="collapse" data-target="#chart{{ forloop.index }}" role="button" onclick="load('#chart{{ forloop.index }}')">
                   <span class="panel-title" >{{ benchmark.url | split: "/" | shift: 3 | pop | join: "/" }}</span>
                 </div>
                 <div id="chart{{ forloop.index }}" class="panel-collapse collapse" style="height: 0px">
@@ -275,7 +275,6 @@ compilers:
           $(this).addClass("active").siblings(".collection").removeClass("active");
           $(".chart:not([data-collection='" + $(this).attr("data-collection") + "'])").hide();
           $(".chart[data-collection='" + $(this).attr("data-collection") + "'][data-compiler='" + compiler + "']").fadeIn();
-          load(".chart:visible");
         });
 
         $(".index > .compilers .compiler").on("click", function(){
@@ -283,7 +282,6 @@ compilers:
           $(this).addClass("active").siblings(".compiler").removeClass("active");
           $(".chart:not([data-compiler='" + $(this).attr("data-compiler") + "'])").hide();
           $(".chart[data-compiler='" + $(this).attr("data-compiler") + "'][data-collection='" + collection + "']").fadeIn();
-          load(".chart:visible");
         });
 
         $(".index > .compilers").on("click", function(){

--- a/index.html
+++ b/index.html
@@ -193,21 +193,6 @@ compilers:
       </div>
     </div>
 
-    <div id="dialog" class="modal fade" data-backdrop="static" data-keyboard="false" role="dialog">
-      <div class="modal-dialog">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h3 class="modal-title">Loading charts...</h3>
-          </div>
-          <div class="modal-body">
-            <div class="progress">
-              <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;"></div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <div id="footer">
       <div class="container">
         <div class="row text-muted">
@@ -240,29 +225,6 @@ compilers:
 
         if(iframes.length <= 0)
           return;
-
-        var dialog = $("#dialog");
-        var bar = $(".progress-bar", dialog).attr("aria-valuenow", 0).css({width: "0%"});
-
-        dialog.modal("toggle");
-
-        var promises = iframes.map(function(idx, iframe){
-          var deferred = $.Deferred().done(function(){
-            bar.attr("aria-valuenow", parseFloat(bar.attr("aria-valuenow")) + 100/iframes.length);
-            bar.css({width: Math.round(bar.attr("aria-valuenow")) + "%"});
-          });
-
-          $(iframe).one("load", deferred.resolve);
-          return deferred.promise();
-        });
-
-        $.when
-          .apply($, promises)
-          .then(function(){
-            setTimeout(function(){
-              dialog.modal("toggle");
-            }, 600);
-          });
 
         iframes.each(function(idx, iframe){
           $(iframe).attr("src", $(iframe).attr("data-src")).removeAttr("data-src");

--- a/index.html
+++ b/index.html
@@ -65,26 +65,6 @@ compilers:
         text-align: right;
       }
 
-      .panel-group .panel-collapse.collapse {
-        display: block;
-      }
-
-      .panel-group .panel-collapse.collapse * {
-        visibility: hidden;
-      }
-
-      .panel-group .panel-collapse.collapse.in * {
-        visibility: visible;
-      }
-
-      .modal-header {
-        padding: 10px 15px;
-      }
-
-      .progress {
-        margin: 0;
-      }
-
       #content {
         height: auto;
         min-height: 100%;
@@ -181,7 +161,7 @@ compilers:
                 <div class="panel-heading" data-toggle="collapse" data-target="#chart{{ forloop.index }}" role="button">
                   <span class="panel-title" >{{ benchmark.url | split: "/" | shift: 3 | pop | join: "/" }}</span>
                 </div>
-                <div id="chart{{ forloop.index }}" class="panel-collapse collapse" style="height: 0px">
+                <div id="chart{{ forloop.index }}" class="panel-collapse collapse">
                   <iframe class="panel-body" data-src="{{ site.baseurl }}{{ benchmark.url }}"></iframe>
                   <div class="panel-footer text-muted">Last updated on {{ benchmark.timestamp }}</div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@ compilers:
             <div class="panel-group">
               {% for benchmark in site.documents %}
               <div class="chart panel panel-default" data-collection="{{ benchmark.collection }}" data-compiler="{{ benchmark.compiler }}" style="display: none">
-                <div class="panel-heading" data-toggle="collapse" data-target="#chart{{ forloop.index }}" role="button" onclick="load('#chart{{ forloop.index }}')">
+                <div class="panel-heading" data-toggle="collapse" data-target="#chart{{ forloop.index }}" role="button">
                   <span class="panel-title" >{{ benchmark.url | split: "/" | shift: 3 | pop | join: "/" }}</span>
                 </div>
                 <div id="chart{{ forloop.index }}" class="panel-collapse collapse" style="height: 0px">
@@ -244,6 +244,10 @@ compilers:
           $(this).addClass("active").siblings(".compiler").removeClass("active");
           $(".chart:not([data-compiler='" + $(this).attr("data-compiler") + "'])").hide();
           $(".chart[data-compiler='" + $(this).attr("data-compiler") + "'][data-collection='" + collection + "']").fadeIn();
+        });
+
+        $(".chart").on("click", function(){
+          load(this);
         });
 
         $(".index > .compilers").on("click", function(){


### PR DESCRIPTION
This reduces the time required for loading the iframes when we view the website initially or when we change the compiler/collection. The second commit of this PR is optional; we could also leave the "Loading" dialog but I find it a bit in the way when loading individual iframes, which is quite fast.

I'll wait for your thoughts about this.