### PR TITLE
Uniformize ranges

### DIFF
--- a/benchmark/dependencies/brigand.cmake
+++ b/benchmark/dependencies/brigand.cmake
@@ -25,7 +25,7 @@ if (METABENCH_BRIGAND)
     endif()
 
     function(Brigand_add_dataset dataset)
-        metabench_add_dataset(${dataset} ${ARGN})
+        metabench_add_dataset(${dataset} ${ARGN} MEDIAN_OF 3)
         target_include_directories(${dataset} PUBLIC ${Brigand_INCLUDE_DIRS})
         add_dependencies(${dataset} Brigand)
     endfunction()

--- a/benchmark/dependencies/hana.cmake
+++ b/benchmark/dependencies/hana.cmake
@@ -29,7 +29,7 @@ if (METABENCH_HANA
     endif()
 
     function(Hana_add_dataset dataset)
-        metabench_add_dataset(${dataset} ${ARGN})
+        metabench_add_dataset(${dataset} ${ARGN} MEDIAN_OF 3)
         target_include_directories(${dataset} PUBLIC ${Hana_INCLUDE_DIRS})
         add_dependencies(${dataset} Hana)
     endfunction()

--- a/benchmark/dependencies/meta.cmake
+++ b/benchmark/dependencies/meta.cmake
@@ -25,7 +25,7 @@ if (METABENCH_META AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"))
     endif()
 
     function(Meta_add_dataset dataset)
-        metabench_add_dataset(${dataset} ${ARGN})
+        metabench_add_dataset(${dataset} ${ARGN} MEDIAN_OF 3)
         target_include_directories(${dataset} PUBLIC ${Meta_INCLUDE_DIRS})
         add_dependencies(${dataset} Meta)
     endfunction()

--- a/benchmark/dependencies/metal.cmake
+++ b/benchmark/dependencies/metal.cmake
@@ -28,7 +28,7 @@ if (METABENCH_METAL AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND
     endif()
 
     function(Metal_add_dataset dataset)
-        metabench_add_dataset(${dataset} ${ARGN})
+        metabench_add_dataset(${dataset} ${ARGN} MEDIAN_OF 3)
         target_include_directories(${dataset} PUBLIC ${METAL_INCLUDE_DIRS})
         add_dependencies(${dataset} Metal)
     endfunction()

--- a/benchmark/dependencies/std.cmake
+++ b/benchmark/dependencies/std.cmake
@@ -9,6 +9,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CMAKE_CXX_COMPILER_VERSION VERSION
     endfunction()
 else()
     function(Std_add_dataset dataset)
-        metabench_add_dataset(${dataset} ${ARGN})
+        metabench_add_dataset(${dataset} ${ARGN} MEDIAN_OF 3)
     endfunction()
 endif()

--- a/benchmark/hetero/at/CMakeLists.txt
+++ b/benchmark/hetero/at/CMakeLists.txt
@@ -3,10 +3,10 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.at.fusion.list      fusion.list.cpp.erb         "(1..50).step(1)")
-add_dataset(datasets dataset.hetero.at.fusion.vector    fusion.vector.cpp.erb       "(1..50).step(1)")
-add_dataset(datasets dataset.hetero.at.hana.basic_tuple hana.basic_tuple.cpp.erb    "(1..500).step(10)")
-add_dataset(datasets dataset.hetero.at.hana.tuple       hana.tuple.cpp.erb          "(1..500).step(10)")
-add_dataset(datasets dataset.hetero.at.std.tuple        std.tuple.cpp.erb           "(1..100).step(10)")
+add_dataset(datasets dataset.hetero.at.fusion.list      fusion.list.cpp.erb         "[1] + (10..50).step(10).to_a")
+add_dataset(datasets dataset.hetero.at.fusion.vector    fusion.vector.cpp.erb       "[1] + (10..50).step(10).to_a")
+add_dataset(datasets dataset.hetero.at.hana.basic_tuple hana.basic_tuple.cpp.erb    "[1] + (10..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.at.hana.tuple       hana.tuple.cpp.erb          "[1] + (10..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.at.std.tuple        std.tuple.cpp.erb           "[1] + (10..50).step(10).to_a + [100]")
 
 add_chart(benchmark.hetero.at DATASETS ${datasets})

--- a/benchmark/hetero/cartesian_product/CMakeLists.txt
+++ b/benchmark/hetero/cartesian_product/CMakeLists.txt
@@ -3,6 +3,6 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.cartesian_product.hana.tuple hana.tuple.cpp.erb "(0..30)")
+add_dataset(datasets dataset.hetero.cartesian_product.hana.tuple hana.tuple.cpp.erb "(0..30).step(5)")
 
 add_chart(benchmark.hetero.cartesian_product DATASETS ${datasets})

--- a/benchmark/hetero/count_if/CMakeLists.txt
+++ b/benchmark/hetero/count_if/CMakeLists.txt
@@ -3,8 +3,8 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.count_if.fusion.list   fusion.list.cpp.erb   "(0...50).step(5)")
-add_dataset(datasets dataset.hetero.count_if.fusion.vector fusion.vector.cpp.erb "(0...50).step(5)")
-add_dataset(datasets dataset.hetero.count_if.hana.tuple    hana.tuple.cpp.erb    "(0...50).step(5).to_a + (50..400).step(25).to_a")
+add_dataset(datasets dataset.hetero.count_if.fusion.list   fusion.list.cpp.erb   "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.count_if.fusion.vector fusion.vector.cpp.erb "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.count_if.hana.tuple    hana.tuple.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.count_if DATASETS ${datasets})

--- a/benchmark/hetero/difference/CMakeLists.txt
+++ b/benchmark/hetero/difference/CMakeLists.txt
@@ -3,6 +3,6 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.difference.hana.set hana.set.cpp.erb "(0...50).step(5)")
+add_dataset(datasets dataset.hetero.difference.hana.set hana.set.cpp.erb "(0..50).step(10)")
 
 add_chart(benchmark.hetero.difference DATASETS ${datasets})

--- a/benchmark/hetero/filter/CMakeLists.txt
+++ b/benchmark/hetero/filter/CMakeLists.txt
@@ -3,8 +3,8 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.filter.fusion.list   fusion.list.cpp.erb   "(0...50).step(5)")
-add_dataset(datasets dataset.hetero.filter.fusion.vector fusion.vector.cpp.erb "(0...50).step(5)")
-add_dataset(datasets dataset.hetero.filter.hana.tuple    hana.tuple.cpp.erb    "(0...50).step(5).to_a + (50..400).step(25).to_a")
+add_dataset(datasets dataset.hetero.filter.fusion.list   fusion.list.cpp.erb   "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.filter.fusion.vector fusion.vector.cpp.erb "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.filter.hana.tuple    hana.tuple.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.filter DATASETS ${datasets})

--- a/benchmark/hetero/find_if/CMakeLists.txt
+++ b/benchmark/hetero/find_if/CMakeLists.txt
@@ -3,10 +3,10 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.find_if.fusion.list   fusion.list.cpp.erb   "(0...50).step(5)")
-add_dataset(datasets dataset.hetero.find_if.fusion.vector fusion.vector.cpp.erb "(0...50).step(5)")
-add_dataset(datasets dataset.hetero.find_if.hana.map      hana.map.cpp.erb      "(0...50).step(5).to_a + (50..200).step(25).to_a")
-add_dataset(datasets dataset.hetero.find_if.hana.set      hana.set.cpp.erb      "(0...50).step(5).to_a + (50..400).step(25).to_a")
-add_dataset(datasets dataset.hetero.find_if.hana.tuple    hana.tuple.cpp.erb    "(0...50).step(5).to_a + (50..400).step(25).to_a")
+add_dataset(datasets dataset.hetero.find_if.fusion.list   fusion.list.cpp.erb   "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.find_if.fusion.vector fusion.vector.cpp.erb "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.find_if.hana.map      hana.map.cpp.erb      "(0..50).step(10).to_a + (100..200).step(100).to_a")
+add_dataset(datasets dataset.hetero.find_if.hana.set      hana.set.cpp.erb      "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.find_if.hana.tuple    hana.tuple.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.find_if DATASETS ${datasets})

--- a/benchmark/hetero/fold_left/CMakeLists.txt
+++ b/benchmark/hetero/fold_left/CMakeLists.txt
@@ -3,9 +3,9 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.fold_left.fusion.list      fusion.list.cpp.erb       "(1..50).step(1)")
-add_dataset(datasets dataset.hetero.fold_left.fusion.vector    fusion.vector.cpp.erb     "(1..50).step(1)")
-add_dataset(datasets dataset.hetero.fold_left.hana.basic_tuple hana.basic_tuple.cpp.erb  "(1..500).step(10)")
-add_dataset(datasets dataset.hetero.fold_left.hana.tuple       hana.tuple.cpp.erb        "(1..500).step(10)")
+add_dataset(datasets dataset.hetero.fold_left.fusion.list      fusion.list.cpp.erb       "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.fold_left.fusion.vector    fusion.vector.cpp.erb     "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.fold_left.hana.basic_tuple hana.basic_tuple.cpp.erb  "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.fold_left.hana.tuple       hana.tuple.cpp.erb        "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.fold_left DATASETS ${datasets})

--- a/benchmark/hetero/fold_right/CMakeLists.txt
+++ b/benchmark/hetero/fold_right/CMakeLists.txt
@@ -3,8 +3,8 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.fold_right.fusion.vector    fusion.vector.cpp.erb     "(1..50).step(1)")
-add_dataset(datasets dataset.hetero.fold_right.hana.basic_tuple hana.basic_tuple.cpp.erb  "(1..500).step(10)")
-add_dataset(datasets dataset.hetero.fold_right.hana.tuple       hana.tuple.cpp.erb        "(1..500).step(10)")
+add_dataset(datasets dataset.hetero.fold_right.fusion.vector    fusion.vector.cpp.erb     "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.fold_right.hana.basic_tuple hana.basic_tuple.cpp.erb  "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.fold_right.hana.tuple       hana.tuple.cpp.erb        "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.fold_right DATASETS ${datasets})

--- a/benchmark/hetero/insert/CMakeLists.txt
+++ b/benchmark/hetero/insert/CMakeLists.txt
@@ -3,7 +3,7 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.insert.hana.map hana.map.cpp.erb "(0...50).step(5).to_a + (50..400).step(25).to_a")
-add_dataset(datasets dataset.hetero.insert.hana.set hana.set.cpp.erb "(0...50).step(5).to_a + (50..400).step(25).to_a")
+add_dataset(datasets dataset.hetero.insert.hana.map hana.map.cpp.erb "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.insert.hana.set hana.set.cpp.erb "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.insert DATASETS ${datasets})

--- a/benchmark/hetero/make/CMakeLists.txt
+++ b/benchmark/hetero/make/CMakeLists.txt
@@ -3,10 +3,10 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.make.fusion.list      fusion.list.cpp.erb         "(0..50).step(1)")
-add_dataset(datasets dataset.hetero.make.fusion.vector    fusion.vector.cpp.erb       "(0..50).step(1)")
-add_dataset(datasets dataset.hetero.make.hana.basic_tuple hana.basic_tuple.cpp.erb    "(0..500).step(10)")
-add_dataset(datasets dataset.hetero.make.hana.tuple       hana.tuple.cpp.erb          "(0..500).step(10)")
-add_dataset(datasets dataset.hetero.make.std.tuple        std.tuple.cpp.erb           "(0..100).step(10)")
+add_dataset(datasets dataset.hetero.make.fusion.list      fusion.list.cpp.erb         "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.make.fusion.vector    fusion.vector.cpp.erb       "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.make.hana.basic_tuple hana.basic_tuple.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.make.hana.tuple       hana.tuple.cpp.erb          "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.make.std.tuple        std.tuple.cpp.erb           "(0..50).step(10).to_a + [100]")
 
 add_chart(benchmark.hetero.make DATASETS ${datasets})

--- a/benchmark/hetero/transform/CMakeLists.txt
+++ b/benchmark/hetero/transform/CMakeLists.txt
@@ -3,9 +3,9 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.transform.fusion.list      fusion.list.cpp.erb        "(0..50).step(1)")
-add_dataset(datasets dataset.hetero.transform.fusion.vector    fusion.vector.cpp.erb      "(0..50).step(1)")
-add_dataset(datasets dataset.hetero.transform.hana.basic_tuple hana.basic_tuple.cpp.erb   "(0..500).step(10)")
-add_dataset(datasets dataset.hetero.transform.hana.tuple       hana.tuple.cpp.erb         "(0..500).step(10)")
+add_dataset(datasets dataset.hetero.transform.fusion.list      fusion.list.cpp.erb        "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.transform.fusion.vector    fusion.vector.cpp.erb      "(0..50).step(10)")
+add_dataset(datasets dataset.hetero.transform.hana.basic_tuple hana.basic_tuple.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.transform.hana.tuple       hana.tuple.cpp.erb         "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.transform DATASETS ${datasets})

--- a/benchmark/hetero/unpack/CMakeLists.txt
+++ b/benchmark/hetero/unpack/CMakeLists.txt
@@ -3,10 +3,10 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.hetero.unpack.fusion.list      fusion.list.cpp.erb        "(0..16).step(1)")
-add_dataset(datasets dataset.hetero.unpack.fusion.vector    fusion.vector.cpp.erb      "(0..16).step(1)")
-add_dataset(datasets dataset.hetero.unpack.hana.basic_tuple hana.basic_tuple.cpp.erb   "(0..500).step(10)")
-add_dataset(datasets dataset.hetero.unpack.hana.set         hana.set.cpp.erb           "(0..500).step(10)")
-add_dataset(datasets dataset.hetero.unpack.hana.tuple       hana.tuple.cpp.erb         "(0..500).step(10)")
+add_dataset(datasets dataset.hetero.unpack.fusion.list      fusion.list.cpp.erb        "(0..15).step(3)")
+add_dataset(datasets dataset.hetero.unpack.fusion.vector    fusion.vector.cpp.erb      "(0..15).step(3)")
+add_dataset(datasets dataset.hetero.unpack.hana.basic_tuple hana.basic_tuple.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.unpack.hana.set         hana.set.cpp.erb           "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.hetero.unpack.hana.tuple       hana.tuple.cpp.erb         "(0..50).step(10).to_a + (100..500).step(100).to_a")
 
 add_chart(benchmark.hetero.unpack DATASETS ${datasets})

--- a/benchmark/type/at/CMakeLists.txt
+++ b/benchmark/type/at/CMakeLists.txt
@@ -3,11 +3,11 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.at.brigand.list   brigand.list.cpp.erb    "(1..500).step(10)")
-add_dataset(datasets dataset.type.at.hana.types     hana.types.cpp.erb      "(1..500).step(10)")
-add_dataset(datasets dataset.type.at.meta.list      meta.list.cpp.erb       "(1..500).step(10)")
-add_dataset(datasets dataset.type.at.metal.list     metal.list.cpp.erb      "(1..500).step(10)")
-add_dataset(datasets dataset.type.at.mpl.list       mpl.list.cpp.erb        "(1..50).step(1)")
-add_dataset(datasets dataset.type.at.mpl.vector     mpl.vector.cpp.erb      "(1..50).step(1)")
+add_dataset(datasets dataset.type.at.brigand.list   brigand.list.cpp.erb    "[1] + (10..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.at.hana.types     hana.types.cpp.erb      "[1] + (10..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.at.meta.list      meta.list.cpp.erb       "[1] + (10..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.at.metal.list     metal.list.cpp.erb      "[1] + (10..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.at.mpl.list       mpl.list.cpp.erb        "[1] + (10..50).step(10).to_a")
+add_dataset(datasets dataset.type.at.mpl.vector     mpl.vector.cpp.erb      "[1] + (10..50).step(10).to_a")
 
 add_chart(benchmark.type.at DATASETS ${datasets})

--- a/benchmark/type/count_if/CMakeLists.txt
+++ b/benchmark/type/count_if/CMakeLists.txt
@@ -3,9 +3,9 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.count_if.meta.list    meta.list.cpp.erb   "(0...500).step(10)")
-add_dataset(datasets dataset.type.count_if.metal.list   metal.list.cpp.erb  "(0...500).step(10)")
-add_dataset(datasets dataset.type.count_if.mpl.list     mpl.list.cpp.erb    "(0...50).step(5)")
-add_dataset(datasets dataset.type.count_if.mpl.vector   mpl.vector.cpp.erb  "(0...50).step(5)")
+add_dataset(datasets dataset.type.count_if.meta.list    meta.list.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.count_if.metal.list   metal.list.cpp.erb  "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.count_if.mpl.list     mpl.list.cpp.erb    "(0..50).step(10)")
+add_dataset(datasets dataset.type.count_if.mpl.vector   mpl.vector.cpp.erb  "(0..50).step(10)")
 
 add_chart(benchmark.type.count_if DATASETS ${datasets})

--- a/benchmark/type/filter/CMakeLists.txt
+++ b/benchmark/type/filter/CMakeLists.txt
@@ -3,9 +3,9 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.filter.meta.list  meta.list.cpp.erb   "(0...500).step(10)")
-add_dataset(datasets dataset.type.filter.metal.list metal.list.cpp.erb  "(0...500).step(10)")
-add_dataset(datasets dataset.type.filter.mpl.list   mpl.list.cpp.erb    "(0...50).step(5)")
-add_dataset(datasets dataset.type.filter.mpl.vector mpl.vector.cpp.erb  "(0...50).step(5)")
+add_dataset(datasets dataset.type.filter.meta.list  meta.list.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.filter.metal.list metal.list.cpp.erb  "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.filter.mpl.list   mpl.list.cpp.erb    "(0..50).step(10)")
+add_dataset(datasets dataset.type.filter.mpl.vector mpl.vector.cpp.erb  "(0..50).step(10)")
 
 add_chart(benchmark.type.filter DATASETS ${datasets})

--- a/benchmark/type/find_if/CMakeLists.txt
+++ b/benchmark/type/find_if/CMakeLists.txt
@@ -3,11 +3,11 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.find_if.brigand.list              brigand.list.cpp.erb                "(0...500).step(10)")
-add_dataset(datasets dataset.type.find_if.hana.std_integer_sequence hana.std_integer_sequence.cpp.erb   "(0...50).step(5).to_a + (50..400).step(25).to_a")
-add_dataset(datasets dataset.type.find_if.meta.list                 meta.list.cpp.erb                   "(0...500).step(10)")
-add_dataset(datasets dataset.type.find_if.metal.list                metal.list.cpp.erb                  "(0...500).step(10)")
-add_dataset(datasets dataset.type.find_if.mpl.list                  mpl.list.cpp.erb                    "(0...50).step(5)")
-add_dataset(datasets dataset.type.find_if.mpl.vector                mpl.vector.cpp.erb                  "(0...50).step(5)")
+add_dataset(datasets dataset.type.find_if.brigand.list              brigand.list.cpp.erb                "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.find_if.hana.std_integer_sequence hana.std_integer_sequence.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.find_if.meta.list                 meta.list.cpp.erb                   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.find_if.metal.list                metal.list.cpp.erb                  "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.find_if.mpl.list                  mpl.list.cpp.erb                    "(0..50).step(10)")
+add_dataset(datasets dataset.type.find_if.mpl.vector                mpl.vector.cpp.erb                  "(0..50).step(10)")
 
 add_chart(benchmark.type.find_if DATASETS ${datasets})

--- a/benchmark/type/fold_left/CMakeLists.txt
+++ b/benchmark/type/fold_left/CMakeLists.txt
@@ -3,10 +3,10 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.fold_left.brigand.list    brigand.list.cpp.erb    "(0...500).step(10)")
-add_dataset(datasets dataset.type.fold_left.meta.list       meta.list.cpp.erb       "(0...500).step(10)")
-add_dataset(datasets dataset.type.fold_left.metal.list      metal.list.cpp.erb      "(0...500).step(10)")
-add_dataset(datasets dataset.type.fold_left.mpl.list        mpl.list.cpp.erb        "(1..50).step(1)")
-add_dataset(datasets dataset.type.fold_left.mpl.vector      mpl.vector.cpp.erb      "(1..50).step(1)")
+add_dataset(datasets dataset.type.fold_left.brigand.list    brigand.list.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.fold_left.meta.list       meta.list.cpp.erb       "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.fold_left.metal.list      metal.list.cpp.erb      "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.fold_left.mpl.list        mpl.list.cpp.erb        "(0..50).step(10)")
+add_dataset(datasets dataset.type.fold_left.mpl.vector      mpl.vector.cpp.erb      "(0..50).step(10)")
 
 add_chart(benchmark.type.fold_left DATASETS ${datasets})

--- a/benchmark/type/fold_right/CMakeLists.txt
+++ b/benchmark/type/fold_right/CMakeLists.txt
@@ -3,9 +3,9 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.fold_right.meta.list  meta.list.cpp.erb   "(0...500).step(10)")
-add_dataset(datasets dataset.type.fold_right.metal.list metal.list.cpp.erb  "(0...500).step(10)")
-add_dataset(datasets dataset.type.fold_right.mpl.list   mpl.list.cpp.erb    "(1..50).step(1)")
-add_dataset(datasets dataset.type.fold_right.mpl.vector mpl.vector.cpp.erb  "(1..50).step(1)")
+add_dataset(datasets dataset.type.fold_right.meta.list  meta.list.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.fold_right.metal.list metal.list.cpp.erb  "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.fold_right.mpl.list   mpl.list.cpp.erb    "(0..50).step(10)")
+add_dataset(datasets dataset.type.fold_right.mpl.vector mpl.vector.cpp.erb  "(0..50).step(10)")
 
 add_chart(benchmark.type.fold_right DATASETS ${datasets})

--- a/benchmark/type/replace_if/CMakeLists.txt
+++ b/benchmark/type/replace_if/CMakeLists.txt
@@ -3,11 +3,11 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.replace_if.brigand.list  brigand.list.cpp.erb "(0..500).step(10)")
-add_dataset(datasets dataset.type.replace_if.hana.types    hana.types.cpp.erb   "(0..500).step(10)")
-add_dataset(datasets dataset.type.replace_if.meta.list     meta.list.cpp.erb    "(0..500).step(10)")
-add_dataset(datasets dataset.type.replace_if.metal.list    metal.list.cpp.erb   "(0..500).step(10)")
-add_dataset(datasets dataset.type.replace_if.mpl.list      mpl.list.cpp.erb     "(0..50).step(1)")
-add_dataset(datasets dataset.type.replace_if.mpl.vector    mpl.vector.cpp.erb   "(0..50).step(1)")
+add_dataset(datasets dataset.type.replace_if.brigand.list  brigand.list.cpp.erb "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.replace_if.hana.types    hana.types.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.replace_if.meta.list     meta.list.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.replace_if.metal.list    metal.list.cpp.erb   "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.replace_if.mpl.list      mpl.list.cpp.erb     "(0..50).step(10)")
+add_dataset(datasets dataset.type.replace_if.mpl.vector    mpl.vector.cpp.erb   "(0..50).step(10)")
 
 add_chart(benchmark.type.replace_if DATASETS ${datasets})

--- a/benchmark/type/reverse/CMakeLists.txt
+++ b/benchmark/type/reverse/CMakeLists.txt
@@ -3,10 +3,10 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.reverse.brigand.list  brigand.list.cpp.erb    "(0..500).step(10)")
-add_dataset(datasets dataset.type.reverse.meta.list     meta.list.cpp.erb       "(0..500).step(10)")
-add_dataset(datasets dataset.type.reverse.metal.list    metal.list.cpp.erb      "(0..500).step(10)")
-add_dataset(datasets dataset.type.reverse.mpl.list      mpl.list.cpp.erb        "(0..50).step(1)")
-add_dataset(datasets dataset.type.reverse.mpl.vector    mpl.vector.cpp.erb      "(0..50).step(1)")
+add_dataset(datasets dataset.type.reverse.brigand.list  brigand.list.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.reverse.meta.list     meta.list.cpp.erb       "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.reverse.metal.list    metal.list.cpp.erb      "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.reverse.mpl.list      mpl.list.cpp.erb        "(0..50).step(10)")
+add_dataset(datasets dataset.type.reverse.mpl.vector    mpl.vector.cpp.erb      "(0..50).step(10)")
 
 add_chart(benchmark.type.reverse DATASETS ${datasets})

--- a/benchmark/type/transform/CMakeLists.txt
+++ b/benchmark/type/transform/CMakeLists.txt
@@ -3,10 +3,10 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 set(datasets)
-add_dataset(datasets dataset.type.transform.brigand.list    brigand.list.cpp.erb    "(0..500).step(10)")
-add_dataset(datasets dataset.type.transform.meta.list       meta.list.cpp.erb       "(0..500).step(10)")
-add_dataset(datasets dataset.type.transform.metal.list      metal.list.cpp.erb      "(0..500).step(10)")
-add_dataset(datasets dataset.type.transform.mpl.list        mpl.list.cpp.erb        "(0..50).step(1)")
-add_dataset(datasets dataset.type.transform.mpl.vector      mpl.vector.cpp.erb      "(0..50).step(1)")
+add_dataset(datasets dataset.type.transform.brigand.list    brigand.list.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.transform.meta.list       meta.list.cpp.erb       "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.transform.metal.list      metal.list.cpp.erb      "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.transform.mpl.list        mpl.list.cpp.erb        "(0..50).step(10)")
+add_dataset(datasets dataset.type.transform.mpl.vector      mpl.vector.cpp.erb      "(0..50).step(10)")
 
 add_chart(benchmark.type.transform DATASETS ${datasets})


### PR DESCRIPTION
The total number of samples were decreased roughly fivefold, while at the same time `MEDIAN_OF 3` was enabled for all libraries. The result are smother benchmarks and a considerable speed up when running the entire benchmark suite.

This PR addresses #106.

![type](https://cloud.githubusercontent.com/assets/4043663/14589149/7e025c1c-04b1-11e6-97f9-598b17fa4415.png)
![hetero](https://cloud.githubusercontent.com/assets/4043663/14589150/7f00359e-04b1-11e6-8c46-928a94f00bd9.png)
