### PR TITLE
Allow loading things in cache on the first iteration

### DIFF
--- a/metabench.cmake
+++ b/metabench.cmake
@@ -374,6 +374,7 @@ file(WRITE ${METABENCH_RB_PATH}
 "      datum['size'] = results.map { |time, size| size }.first                                      \n"
 "      return datum                                                                                 \n"
 "    }                                                                                              \n"
+"    compile[code] if index == 0 # Fill the cahce on the first iteration                            \n"
 "    base = compile[code]                                                                           \n"
 "    datum = compile[%{#define METABENCH\\n} + code]                                                \n"
 "    datum['time'] = datum['time'] - base['time']                                                   \n"


### PR DESCRIPTION
By compiling the code one time without remembering the results on the first iteration, we allow the caches to heat up. Otherwise, the first measurement appears to be very slow compared to the following ones, because caches are not hot yet.