### PR TITLE
Make sure MPL benchmarks are representative

### DIFF
--- a/benchmark/type/at/brigand.list.cpp.erb
+++ b/benchmark/type/at/brigand.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <brigand/sequences/at.hpp>
 #include <brigand/sequences/list.hpp>
 #include <brigand/types/integer.hpp>
@@ -12,7 +13,6 @@ using list = brigand::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = brigand::at<list, brigand::int32_t<<%= n - 1 %>>>;
 #endif
 

--- a/benchmark/type/at/meta.list.cpp.erb
+++ b/benchmark/type/at/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 template<int> struct x;
@@ -10,7 +11,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::at_c<list, <%= n - 1 %>>;
 #endif
 

--- a/benchmark/type/at/metal.list.cpp.erb
+++ b/benchmark/type/at/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<int> struct x;
@@ -10,7 +11,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::at<list, metal::int_<<%= n - 1 %>>>;
 #endif
 

--- a/benchmark/type/at/mpl.list.cpp.erb
+++ b/benchmark/type/at/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/at.hpp>
 namespace mpl = boost::mpl;
@@ -17,7 +18,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::at_c<list, <%= n - 1 %>>::type;
 #endif
 

--- a/benchmark/type/at/mpl.vector.cpp.erb
+++ b/benchmark/type/at/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/at.hpp>
 namespace mpl = boost::mpl;
@@ -17,7 +18,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::at_c<vector, <%= n - 1 %>>::type;
 #endif
 

--- a/benchmark/type/count_if/meta.list.cpp.erb
+++ b/benchmark/type/count_if/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 struct is_even {
@@ -13,7 +14,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "meta::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::count_if<list, is_even>;
 #endif
 

--- a/benchmark/type/count_if/metal.list.cpp.erb
+++ b/benchmark/type/count_if/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename N>
@@ -11,7 +12,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::count_if<list, metal::lambda<is_even>>;
 #endif
 

--- a/benchmark/type/count_if/mpl.list.cpp.erb
+++ b/benchmark/type/count_if/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/count_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::count_if<list, is_even>::type;
 #endif
 

--- a/benchmark/type/count_if/mpl.vector.cpp.erb
+++ b/benchmark/type/count_if/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/count_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::count_if<vector, is_even>::type;
 #endif
 

--- a/benchmark/type/filter/meta.list.cpp.erb
+++ b/benchmark/type/filter/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 struct is_even {
@@ -13,7 +14,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "meta::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::filter<list, is_even>;
 #endif
 

--- a/benchmark/type/filter/metal.list.cpp.erb
+++ b/benchmark/type/filter/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename N>
@@ -11,7 +12,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::copy_if<list, metal::lambda<is_even>>;
 #endif
 

--- a/benchmark/type/filter/mpl.list.cpp.erb
+++ b/benchmark/type/filter/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/copy_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::copy_if<list, is_even>::type;
 #endif
 

--- a/benchmark/type/filter/mpl.vector.cpp.erb
+++ b/benchmark/type/filter/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/copy_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::copy_if<vector, is_even>::type;
 #endif
 

--- a/benchmark/type/find_if/brigand.list.cpp.erb
+++ b/benchmark/type/find_if/brigand.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <brigand/sequences/list.hpp>
 #include <brigand/algorithms/find.hpp>
 #include <brigand/types/bool.hpp>
@@ -16,7 +17,6 @@ using list = brigand::list<
     <%= (1..n).map { |i| "brigand::int32_t<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = brigand::find<list, is_last>;
 #endif
 

--- a/benchmark/type/find_if/meta.list.cpp.erb
+++ b/benchmark/type/find_if/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 struct is_last {
@@ -13,7 +14,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "meta::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::find_if<list, is_last>;
 #endif
 

--- a/benchmark/type/find_if/metal.list.cpp.erb
+++ b/benchmark/type/find_if/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename N>
@@ -11,7 +12,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::find_if<list, metal::lambda<is_last>>;
 #endif
 

--- a/benchmark/type/find_if/mpl.list.cpp.erb
+++ b/benchmark/type/find_if/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/find_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::find_if<list, is_last>::type;
 #endif
 

--- a/benchmark/type/find_if/mpl.vector.cpp.erb
+++ b/benchmark/type/find_if/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/find_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::find_if<vector, is_last>::type;
 #endif
 

--- a/benchmark/type/fold_left/brigand.list.cpp.erb
+++ b/benchmark/type/fold_left/brigand.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <brigand/sequences/list.hpp>
 #include <brigand/algorithms/fold.hpp>
 
@@ -20,7 +21,6 @@ using list = brigand::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = brigand::fold<list, state, f>;
 #endif
 

--- a/benchmark/type/fold_left/meta.list.cpp.erb
+++ b/benchmark/type/fold_left/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 struct f {
@@ -17,7 +18,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::fold<list, state, f>;
 #endif
 

--- a/benchmark/type/fold_left/metal.list.cpp.erb
+++ b/benchmark/type/fold_left/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename, typename X>
@@ -15,7 +16,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::fold<list, state, metal::lambda<f>>;
 #endif
 

--- a/benchmark/type/fold_left/mpl.list.cpp.erb
+++ b/benchmark/type/fold_left/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/fold.hpp>
 namespace mpl = boost::mpl;
@@ -26,7 +27,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::fold<list, state, f>::type;
 #endif
 

--- a/benchmark/type/fold_left/mpl.vector.cpp.erb
+++ b/benchmark/type/fold_left/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/fold.hpp>
 namespace mpl = boost::mpl;
@@ -26,7 +27,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::fold<vector, state, f>::type;
 #endif
 

--- a/benchmark/type/fold_right/meta.list.cpp.erb
+++ b/benchmark/type/fold_right/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 struct f {
@@ -17,7 +18,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::reverse_fold<list, state, f>;
 #endif
 

--- a/benchmark/type/fold_right/metal.list.cpp.erb
+++ b/benchmark/type/fold_right/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename, typename X>
@@ -15,7 +16,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::fold<
     list, state, metal::lambda<f>, metal::size_t<<%= n %>>, metal::size_t<0>
 >;

--- a/benchmark/type/fold_right/mpl.list.cpp.erb
+++ b/benchmark/type/fold_right/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/reverse_fold.hpp>
 namespace mpl = boost::mpl;
@@ -26,7 +27,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::reverse_fold<list, state, f>::type;
 #endif
 

--- a/benchmark/type/fold_right/mpl.vector.cpp.erb
+++ b/benchmark/type/fold_right/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/reverse_fold.hpp>
 namespace mpl = boost::mpl;
@@ -26,7 +27,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::reverse_fold<vector, state, f>::type;
 #endif
 

--- a/benchmark/type/make/meta.list.cpp.erb
+++ b/benchmark/type/make/meta.list.cpp.erb
@@ -2,11 +2,11 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 template<int> struct x;
 
-#if defined(METABENCH)
 using list = meta::list<<%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>>;
 #endif
 

--- a/benchmark/type/make/metal.list.cpp.erb
+++ b/benchmark/type/make/metal.list.cpp.erb
@@ -2,11 +2,11 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<int> struct x;
 
-#if defined(METABENCH)
 using list = metal::list<<%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>>;
 #endif
 

--- a/benchmark/type/make/mpl.list.cpp.erb
+++ b/benchmark/type/make/mpl.list.cpp.erb
@@ -7,12 +7,12 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 namespace mpl = boost::mpl;
 
 template<int> struct x;
 
-#if defined(METABENCH)
 using list = mpl::list<<%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>>;
 #endif
 

--- a/benchmark/type/make/mpl.vector.cpp.erb
+++ b/benchmark/type/make/mpl.vector.cpp.erb
@@ -7,12 +7,12 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 namespace mpl = boost::mpl;
 
 template<int> struct x;
 
-#if defined(METABENCH)
 using vector = mpl::vector<<%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>>;
 #endif
 

--- a/benchmark/type/partition/metal.list.cpp.erb
+++ b/benchmark/type/partition/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename N>
@@ -11,7 +12,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::partition<list, metal::lambda<is_even>>;
 #endif
 

--- a/benchmark/type/partition/mpl.list.cpp.erb
+++ b/benchmark/type/partition/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/partition.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::partition<list, is_even>::type;
 #endif
 

--- a/benchmark/type/partition/mpl.vector.cpp.erb
+++ b/benchmark/type/partition/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/partition.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::partition<vector, is_even>::type;
 #endif
 

--- a/benchmark/type/replace_if/brigand.list.cpp.erb
+++ b/benchmark/type/replace_if/brigand.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <brigand/sequences/list.hpp>
 #include <brigand/algorithms/replace.hpp>
 #include <brigand/types/bool.hpp>
@@ -16,7 +17,6 @@ using list = brigand::list<
     <%= (1..n).map { |i| "brigand::int32_t<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = brigand::replace_if<list, is_even, void>;
 #endif
 

--- a/benchmark/type/replace_if/meta.list.cpp.erb
+++ b/benchmark/type/replace_if/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 struct is_even {
@@ -13,7 +14,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "meta::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::replace_if<list, is_even, void>;
 #endif
 

--- a/benchmark/type/replace_if/metal.list.cpp.erb
+++ b/benchmark/type/replace_if/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename N>
@@ -11,7 +12,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::replace_if<list, metal::lambda<is_even>, void>;
 #endif
 

--- a/benchmark/type/replace_if/mpl.list.cpp.erb
+++ b/benchmark/type/replace_if/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/replace_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::replace_if<list, is_even, void>::type;
 #endif
 

--- a/benchmark/type/replace_if/mpl.vector.cpp.erb
+++ b/benchmark/type/replace_if/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/replace_if.hpp>
 #include <boost/mpl/bool.hpp>
@@ -22,7 +23,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "mpl::int_<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::replace_if<vector, is_even, void>::type;
 #endif
 

--- a/benchmark/type/reverse/brigand.list.cpp.erb
+++ b/benchmark/type/reverse/brigand.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <brigand/sequences/list.hpp>
 #include <brigand/algorithms/reverse.hpp>
 
@@ -11,7 +12,6 @@ using list = brigand::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = brigand::reverse<list>;
 #endif
 

--- a/benchmark/type/reverse/meta.list.cpp.erb
+++ b/benchmark/type/reverse/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 template<int> struct x;
@@ -10,7 +11,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::reverse<list>;
 #endif
 

--- a/benchmark/type/reverse/metal.list.cpp.erb
+++ b/benchmark/type/reverse/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<int> struct x;
@@ -10,7 +11,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::reverse<list>;
 #endif
 

--- a/benchmark/type/reverse/mpl.list.cpp.erb
+++ b/benchmark/type/reverse/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/reverse.hpp>
 namespace mpl = boost::mpl;
@@ -17,7 +18,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::reverse<list>::type;
 #endif
 

--- a/benchmark/type/reverse/mpl.vector.cpp.erb
+++ b/benchmark/type/reverse/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/reverse.hpp>
 namespace mpl = boost::mpl;
@@ -17,7 +18,6 @@ using vector = mpl::vector<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::reverse<vector>::type;
 #endif
 

--- a/benchmark/type/transform/brigand.list.cpp.erb
+++ b/benchmark/type/transform/brigand.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <brigand/sequences/list.hpp>
 #include <brigand/algorithms/transform.hpp>
 
@@ -18,7 +19,6 @@ using list = brigand::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = brigand::transform<list, f>;
 #endif
 

--- a/benchmark/type/transform/meta.list.cpp.erb
+++ b/benchmark/type/transform/meta.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <meta/meta.hpp>
 
 struct f {
@@ -15,7 +16,6 @@ using list = meta::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = meta::transform<list, f>;
 #endif
 

--- a/benchmark/type/transform/metal.list.cpp.erb
+++ b/benchmark/type/transform/metal.list.cpp.erb
@@ -2,6 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#if defined(METABENCH)
 #include <metal.hpp>
 
 template<typename X>
@@ -13,7 +14,6 @@ using list = metal::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = metal::transform<metal::lambda<f>, list>;
 #endif
 

--- a/benchmark/type/transform/mpl.list.cpp.erb
+++ b/benchmark/type/transform/mpl.list.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_LIST_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/list.hpp>
 #include <boost/mpl/transform.hpp>
 namespace mpl = boost::mpl;
@@ -24,7 +25,6 @@ using list = mpl::list<
     <%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>
 >;
 
-#if defined(METABENCH)
 using result = mpl::transform<list, f>::type;
 #endif
 

--- a/benchmark/type/transform/mpl.vector.cpp.erb
+++ b/benchmark/type/transform/mpl.vector.cpp.erb
@@ -7,6 +7,7 @@
     #define BOOST_MPL_LIMIT_VECTOR_SIZE <%= ((n + 9) / 10) * 10 %>
 <% end %>
 
+#if defined(METABENCH)
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/transform.hpp>
 namespace mpl = boost::mpl;
@@ -22,7 +23,6 @@ template<int> struct x;
 
 using vector = mpl::vector<<%= (1..n).map { |i| "x<#{i}>" }.join(', ') %>>;
 
-#if defined(METABENCH)
 using result = mpl::transform<vector, f>::type;
 #endif
 


### PR DESCRIPTION
Contrary to heterogeneous tuples, constructing pure type lists is basically free, so we can really afford to benchmark the preprocessor for pure type libraries. This is particularly important in order for MPL benchmarks to be representative of the end user experience, while Brigand, Meta and Metal are mostly unaffected by these changes. Hana is out of scope here since it is not pure type library, but it shouldn't matter anyways since I don't believe it relies on the preprocessor too much.