### PR TITLE
Avoid erasing previous benchmarks if something goes wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,10 +113,10 @@ script:
   # triggers the nightly build.
   - |
     if [[ "${METABENCH_NIGHTLY_BUILD}" == "true" && "${CMAKE_GENERATOR}" == "Unix Makefiles" ]]; then
-      cmake --build build --target benchmarks
+      cmake --build build --target benchmarks &&
 
       # Suppress output to avoid leaking the token when the command fails
-      git clone https://ldionne:${GITHUB_TOKEN}@github.com/ldionne/metabench --depth 1 --branch=gh-pages tmp &>/dev/null
+      git clone https://ldionne:${GITHUB_TOKEN}@github.com/ldionne/metabench --depth 1 --branch=gh-pages tmp &>/dev/null &&
       for collection in hetero type; do
         rm -rf tmp/_${collection}/${COMPILER}
         rsync -am --include '*/' --include '*.html' --include '*.json' --exclude '*' build/benchmark/${collection}/ tmp/_${collection}/${COMPILER}


### PR DESCRIPTION
It's better to show outdated benchmarks than no benchmarks at all