### PR TITLE
[Travis] Add support for Clang 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
       - clang-3.6
       - clang-3.7
       - clang-3.8
+      - clang-3.9
       - g++-4.8
       - g++-4.9
       - g++-5
@@ -33,6 +34,7 @@ addons:
       - llvm-toolchain-precise-3.6
       - llvm-toolchain-precise-3.7
       - llvm-toolchain-precise-3.8
+      - llvm-toolchain-precise-3.9
       - llvm-toolchain-precise
 
 env:
@@ -48,6 +50,8 @@ env:
     - COMPILER=clang++-3.7 CMAKE_GENERATOR="Unix Makefiles" CATEGORY=type
     - COMPILER=clang++-3.8 CMAKE_GENERATOR="Unix Makefiles" CATEGORY=hetero
     - COMPILER=clang++-3.8 CMAKE_GENERATOR="Unix Makefiles" CATEGORY=type
+    - COMPILER=clang++-3.9 CMAKE_GENERATOR="Unix Makefiles" CATEGORY=hetero
+    - COMPILER=clang++-3.9 CMAKE_GENERATOR="Unix Makefiles" CATEGORY=type
     - COMPILER=g++-4.8     CMAKE_GENERATOR="Unix Makefiles" CATEGORY=hetero
     - COMPILER=g++-4.8     CMAKE_GENERATOR="Unix Makefiles" CATEGORY=type
     - COMPILER=g++-4.9     CMAKE_GENERATOR="Unix Makefiles" CATEGORY=hetero
@@ -76,10 +80,12 @@ install:
 
   # Install libc++ and libc++abi if needed
   - |
-    if [[ "${CXX}" == "clang++-3.6" || "${CXX}" == "clang++-3.7" || "${CXX}" == "clang++-3.8" ]]; then
+    if [[ "${CXX%%+*}" == "clang" ]]; then
       if   [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
       elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
-      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1"; fi
+      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1";
+      elif [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.0";
+      fi
 
       LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
       LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,31 +62,33 @@ env:
 
 install:
   - export CXX=${COMPILER} # Override CXX set by Travis
+  - ${CXX} --version
 
   # All the dependencies are installed in ${TRAVIS_BUILD_DIR}/deps/
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
   - mkdir -p ${DEPS_DIR} && cd ${DEPS_DIR}
 
   # Install a recent CMake
-  - CMAKE_URL="http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz"
-  - mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
+  - CMAKE_URL="http://www.cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz"
+  - mkdir cmake && travis_retry wget --no-check-certificate -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
   - export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+  - cmake --version
 
   # Install libc++ and libc++abi if needed
   - |
     if [[ "${CXX}" == "clang++-3.6" || "${CXX}" == "clang++-3.7" || "${CXX}" == "clang++-3.8" ]]; then
       if   [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
       elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
-      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.0"; fi
+      elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1"; fi
 
       LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
       LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
       LIBCXXABI_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"
 
       mkdir -p llvm llvm/build llvm/projects/libcxx llvm/projects/libcxxabi
-      travis_retry wget --quiet -O - ${LLVM_URL} | tar --strip-components=1 -xJ -C llvm
-      travis_retry wget --quiet -O - ${LIBCXX_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxx
-      travis_retry wget --quiet -O - ${LIBCXXABI_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxxabi
+      travis_retry wget -O - ${LLVM_URL} | tar --strip-components=1 -xJ -C llvm
+      travis_retry wget -O - ${LIBCXX_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxx
+      travis_retry wget -O - ${LIBCXXABI_URL} | tar --strip-components=1 -xJ -C llvm/projects/libcxxabi
       (cd llvm/build && cmake .. -DCMAKE_INSTALL_PREFIX=${DEPS_DIR}/llvm/install)
       (cd llvm/build/projects/libcxx && make install -j2)
       (cd llvm/build/projects/libcxxabi && make install -j2)
@@ -108,6 +110,7 @@ install:
 
   # Install and use a more recent Ruby
   - rvm use 2.1 --install --binary --fuzzy
+  - ruby --version
 
 before_script:
   # Set the git identity (for pushing the benchmarks)


### PR DESCRIPTION
[Clang 3.9 is currently being tagged](http://llvm.1065342.n5.nabble.com/llvm-dev-3-9-Release-Release-Candidate-1-has-been-tagged-tp99158.html). Once it is officially released, we can start testing on it using this PR.
