### PR TITLE
Add benchmarks for all

### DIFF
--- a/benchmark/type/all/CMakeLists.txt
+++ b/benchmark/type/all/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright Bruno Dutra 2016
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+set(datasets)
+add_dataset(datasets dataset.type.all.brigand.list  brigand.list.cpp.erb    "(0..50).step(10).to_a + (100..500).step(100).to_a")
+add_dataset(datasets dataset.type.all.metal.list    metal.list.cpp.erb      "(0..50).step(10).to_a + (100..500).step(100).to_a")
+#add_dataset(datasets dataset.type.all.meta.list    meta.list.cpp.erb      "(0..50).step(10).to_a + (100..500).step(100).to_a")
+
+add_chart(benchmark.type.all DATASETS ${datasets})

--- a/benchmark/type/all/brigand.list.cpp.erb
+++ b/benchmark/type/all/brigand.list.cpp.erb
@@ -1,0 +1,19 @@
+// Copyright Bruno Dutra 2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#define BRIGAND_NO_BOOST_SUPPORT
+#include <brigand/brigand.hpp>
+
+template<typename N>
+using is_positive = brigand::bool_<(N::type::value > 0)>;
+
+using list = brigand::list<
+    <%= (1..n).map { |i| "brigand::int32_t<#{i}>" }.join(', ') %>
+>;
+
+#if defined(METABENCH)
+using result = brigand::all<list, brigand::bind<is_positive, brigand::_1>>;
+#endif
+
+int main() { }

--- a/benchmark/type/all/meta.list.cpp.erb
+++ b/benchmark/type/all/meta.list.cpp.erb
@@ -1,0 +1,20 @@
+// Copyright Bruno Dutra 2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <meta/meta.hpp>
+
+struct is_positive {
+    template<typename N>
+    using invoke = meta::bool_<(N::type::value > 0)>;
+};
+
+using list = meta::list<
+    <%= (1..n).map { |i| "meta::int_<#{i}>" }.join(', ') %>
+>;
+
+#if defined(METABENCH)
+using result = meta::all_of<list, is_positive>;
+#endif
+
+int main() { }

--- a/benchmark/type/all/metal.list.cpp.erb
+++ b/benchmark/type/all/metal.list.cpp.erb
@@ -1,0 +1,18 @@
+// Copyright Bruno Dutra 2016
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <metal.hpp>
+
+template<typename N>
+using is_positive = metal::number<(N::type::value > 0)>;
+
+using list = metal::list<
+    <%= (1..n).map { |i| "metal::number<#{i}>" }.join(', ') %>
+>;
+
+#if defined(METABENCH)
+using result = metal::all<list, metal::lambda<is_positive>>;
+#endif
+
+int main() { }

--- a/benchmark/type/at/metal.list.cpp.erb
+++ b/benchmark/type/at/metal.list.cpp.erb
@@ -11,7 +11,7 @@ using list = metal::list<
 >;
 
 #if defined(METABENCH)
-using result = metal::at<list, metal::int_<<%= n - 1 %>>>;
+using result = metal::at<list, metal::number<<%= n - 1 %>>>;
 #endif
 
 int main() { }

--- a/benchmark/type/count_if/metal.list.cpp.erb
+++ b/benchmark/type/count_if/metal.list.cpp.erb
@@ -5,10 +5,10 @@
 #include <metal.hpp>
 
 template<typename N>
-using is_even = metal::bool_<N::type::value % 2 == 0>;
+using is_even = metal::number<N::type::value % 2 == 0>;
 
 using list = metal::list<
-    <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
+    <%= (1..n).map { |i| "metal::number<#{i}>" }.join(', ') %>
 >;
 
 #if defined(METABENCH)

--- a/benchmark/type/filter/metal.list.cpp.erb
+++ b/benchmark/type/filter/metal.list.cpp.erb
@@ -5,10 +5,10 @@
 #include <metal.hpp>
 
 template<typename N>
-using is_even = metal::bool_<N::type::value % 2 == 0>;
+using is_even = metal::number<N::type::value % 2 == 0>;
 
 using list = metal::list<
-    <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
+    <%= (1..n).map { |i| "metal::number<#{i}>" }.join(', ') %>
 >;
 
 #if defined(METABENCH)

--- a/benchmark/type/find_if/metal.list.cpp.erb
+++ b/benchmark/type/find_if/metal.list.cpp.erb
@@ -5,10 +5,10 @@
 #include <metal.hpp>
 
 template<typename N>
-using is_last = metal::bool_<N::type::value == <%= n %>>;
+using is_last = metal::number<N::type::value == <%= n %>>;
 
 using list = metal::list<
-    <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
+    <%= (1..n).map { |i| "metal::number<#{i}>" }.join(', ') %>
 >;
 
 #if defined(METABENCH)

--- a/benchmark/type/fold_left/metal.list.cpp.erb
+++ b/benchmark/type/fold_left/metal.list.cpp.erb
@@ -16,7 +16,7 @@ using list = metal::list<
 >;
 
 #if defined(METABENCH)
-using result = metal::fold<list, state, metal::lambda<f>>;
+using result = metal::fold_left<list, state, metal::lambda<f>>;
 #endif
 
 int main() { }

--- a/benchmark/type/fold_right/metal.list.cpp.erb
+++ b/benchmark/type/fold_right/metal.list.cpp.erb
@@ -16,9 +16,7 @@ using list = metal::list<
 >;
 
 #if defined(METABENCH)
-using result = metal::fold<
-    list, state, metal::lambda<f>, metal::size_t<<%= n %>>, metal::size_t<0>
->;
+using result = metal::fold_right<list, state, metal::lambda<f>>;
 #endif
 
 int main() { }

--- a/benchmark/type/partition/metal.list.cpp.erb
+++ b/benchmark/type/partition/metal.list.cpp.erb
@@ -5,10 +5,10 @@
 #include <metal.hpp>
 
 template<typename N>
-using is_even = metal::bool_<N::type::value % 2 == 0>;
+using is_even = metal::number<N::type::value % 2 == 0>;
 
 using list = metal::list<
-    <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
+    <%= (1..n).map { |i| "metal::number<#{i}>" }.join(', ') %>
 >;
 
 #if defined(METABENCH)

--- a/benchmark/type/replace_if/metal.list.cpp.erb
+++ b/benchmark/type/replace_if/metal.list.cpp.erb
@@ -5,10 +5,10 @@
 #include <metal.hpp>
 
 template<typename N>
-using is_even = metal::bool_<N::type::value % 2 == 0>;
+using is_even = metal::number<N::type::value % 2 == 0>;
 
 using list = metal::list<
-    <%= (1..n).map { |i| "metal::int_<#{i}>" }.join(', ') %>
+    <%= (1..n).map { |i| "metal::number<#{i}>" }.join(', ') %>
 >;
 
 #if defined(METABENCH)


### PR DESCRIPTION
Meta is disabled because it currently fails this benchmark with the following error on Clang 4.0

> error: pack expansion used as argument for non-pack parameter of alias template
>        `using invoke = typename F::template invoke<Args...>;`

@ericniebler did I do anything wrong?

**Note:** This is based on #137 