### PR TITLE
Change the interpolation mode from 'basis' to 'cardinal'

### DIFF
--- a/metabench.cmake
+++ b/metabench.cmake
@@ -608,7 +608,7 @@ file(WRITE ${CHART_HTML_ERB_PATH}
 "             });                                                                                                           \n"
 "      }                                                                                                                    \n"
 "                                                                                                                           \n"
-"      chart.interpolate('basis').useInteractiveGuideline(true);                                                            \n"
+"      chart.interpolate('cardinal').useInteractiveGuideline(true);                                                            \n"
 "      d3.select('#chart').datum(data).call(chart);                                                                         \n"
 "      var plot = d3.select('#chart > g');                                                                                  \n"
 "                                                                                                                           \n"


### PR DESCRIPTION
Doing so will provide a accurate match to the data, while preserving
the desired smoothing behavior.

A better option might be to provide options for all three
interpolation modes ([none](https://github.com/d3/d3-shape/blob/master/README.md#curveLinear), [cardinal](https://github.com/d3/d3-shape/blob/master/README.md#curveCardinal), [B-spline](https://github.com/d3/d3-shape/blob/master/README.md#curveBasis)), as the B-spline
interpolation is still desirable under certain circumstances such as
data with a high amount of noise.

For a reference of all the interpolation modes see:
https://github.com/d3/d3-shape/blob/master/README.md#curves