### PR TITLE
Collect peak memory usage during compilation

### DIFF
--- a/test/add_chart_aspect_peak_memory/CMakeLists.txt
+++ b/test/add_chart_aspect_peak_memory/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright Louis Dionne 2016
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+# This test makes sure that using the PEAK_MEMORY aspect with metabench_add_chart
+# produces a graph of the peak memory usage. The test does not actually check
+# anything; this must be done by manual inspection. Since we compile the same
+# code several times over, the peak memory usage should be consistent.
+
+cmake_minimum_required(VERSION 3.1)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+include(metabench)
+
+metabench_add_dataset(dummy "dummy.cpp.erb" "[1, 2, 3, 4, 5]")
+metabench_add_chart(check ASPECT PEAK_MEMORY DATASETS dummy)

--- a/test/add_chart_aspect_peak_memory/dummy.cpp.erb
+++ b/test/add_chart_aspect_peak_memory/dummy.cpp.erb
@@ -1,0 +1,25 @@
+template <typename Left, typename Right>
+struct expr {
+    Left left; Right right;
+    void operator()() const {
+        left(); right();
+    }
+};
+
+template <typename Left, typename Right>
+expr<Left, Right> operator+(Left const& left, Right const& right) {
+    return {left, right};
+}
+
+template <int>
+struct Leaf {
+    void operator()() const { }
+};
+
+int main() {
+    Leaf<1> a;
+    Leaf<2> b;
+
+    (((a + b) + (a + b)) + ((a + b) + (a + b)) +
+        ((a + b) + (a + b)) + ((a + b) + (a + b)))();
+}


### PR DESCRIPTION
This fixes #17 and provides a valuable source of information.

I think the next step would be to always forward all the information to the charts and allow switching between different aspects at the Javascript level instead of hardcoding that in CMake.